### PR TITLE
for easy local tests and optimise tasks count

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,10 +7,11 @@ plugins {
     id("com.gradle.plugin-publish") version ("0.14.0")
     id("com.github.kukuhyoniatmoko.buildconfigkotlin") version ("1.0.5")
     id("java-gradle-plugin")
+    id("org.gradle.maven-publish")
 }
 
 group = "dev.icerock.gradle"
-version = "2.0.1"
+version = "2.0.2"
 
 repositories {
     jcenter()

--- a/plugin/src/main/kotlin/dev/icerock/gradle/talaiot/InfluxDbPublisher.kt
+++ b/plugin/src/main/kotlin/dev/icerock/gradle/talaiot/InfluxDbPublisher.kt
@@ -89,7 +89,9 @@ class InfluxDbPublisher(
     }
 
     private fun createTaskPoints(report: ExecutionReport): List<Point>? {
-        return report.tasks?.map { task ->
+        return report.tasks?.filter { task ->
+            task.ms.div(1000.0) >= 30.0
+        }?.map { task ->
             val dataProvider: ValuesProvider = DefaultTaskDataProvider(task, report)
 
             Point.measurement(configuration.taskMetricName)

--- a/plugin/src/main/kotlin/dev/icerock/gradle/talaiot/InfluxDbPublisher.kt
+++ b/plugin/src/main/kotlin/dev/icerock/gradle/talaiot/InfluxDbPublisher.kt
@@ -17,6 +17,9 @@ import io.github.cdsap.talaiot.metrics.ValuesProvider
 import io.github.cdsap.talaiot.publisher.Publisher
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.logging.Logger
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+import kotlin.time.seconds
 
 class InfluxDbPublisher(
     private val configuration: Configuration,
@@ -88,9 +91,10 @@ class InfluxDbPublisher(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
     private fun createTaskPoints(report: ExecutionReport): List<Point>? {
         return report.tasks?.filter { task ->
-            task.ms.div(1000.0) >= 30.0
+            task.ms.milliseconds >= 30.seconds
         }?.map { task ->
             val dataProvider: ValuesProvider = DefaultTaskDataProvider(task, report)
 


### PR DESCRIPTION
save tasks longer than 30 seconds for more free space in influxDB
using maven-publish plugin for easier local test